### PR TITLE
Add Godot main menu with translation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# temp2
+# Godot Main Menu Example
+
+This repository contains a minimal Godot project configured with a simple main menu.
+The main menu demonstrates loading translations for the "LOAD GAME" option.
+
+## Structure
+- `project.godot` – Godot project settings with the main scene configured.
+- `scenes/` – Contains the `main_menu.tscn` scene.
+- `scripts/` – GDScript for handling menu actions.
+- `translations/ru.csv` – Russian translation for menu text.
+
+Use this project as a starting point for your Godot game.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,8 @@
+; Engine configuration file.
+config_version=5
+
+[application]
+run/main_scene="res://scenes/main_menu.tscn"
+
+[locale]
+translations=["res://translations/ru.csv"]

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=3]
+
+[node name="MainMenu" type="Control"]
+script = ExtResource("res://scripts/main_menu.gd")
+
+[node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="NewGameButton" type="Button" parent="VBox"]
+text = "NEW GAME"
+
+[node name="LoadGameButton" type="Button" parent="VBox"]
+text = "LOAD GAME"
+
+[node name="QuitButton" type="Button" parent="VBox"]
+text = "QUIT"

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -1,0 +1,20 @@
+extends Control
+
+func _ready():
+    var locale = TranslationServer.get_locale()
+    TranslationServer.set_locale(locale)
+
+    $VBox/NewGameButton.connect("pressed", self, "_on_new_game_pressed")
+    $VBox/LoadGameButton.connect("pressed", self, "_on_load_game_pressed")
+    $VBox/QuitButton.connect("pressed", self, "_on_quit_pressed")
+
+func _on_new_game_pressed():
+    print("Starting new game...")
+    # TODO: Replace with game start logic
+
+func _on_load_game_pressed():
+    print("Loading saved game...")
+    # TODO: Replace with load game logic
+
+func _on_quit_pressed():
+    get_tree().quit()

--- a/translations/ru.csv
+++ b/translations/ru.csv
@@ -1,0 +1,4 @@
+text;translation
+LOAD GAME;Загрузить игру
+NEW GAME;Новая игра
+QUIT;Выйти


### PR DESCRIPTION
## Summary
- add Godot project configuration with a main menu scene
- implement basic `MainMenu` script connecting button actions
- include Russian translation for menu text
- update README with project overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ec80a37bc832aaa79deb6286faa2f